### PR TITLE
fixes TypeError of the setShortcuts method

### DIFF
--- a/hide_new_cards_until_next_day/__init__.py
+++ b/hide_new_cards_until_next_day/__init__.py
@@ -187,7 +187,7 @@ gui_hooks.profile_will_close.append(marker_main)
 
 # create a new menu item
 action = QAction("Hide new cards until next day", mw)
-action.setShortcuts(QKeySequence("Ctrl+Alt+t"))
+action.setShortcut(QKeySequence("Ctrl+Alt+t"))
 
 # set it to call testFunction when it's clicked
 qconnect(action.triggered, marker_main)


### PR DESCRIPTION
setShortcuts() expects an array and throws a TypeError from the way it is used. I propose the change of the method to the singular form, as only one shortcut is being set, fixing the TypeError bug.